### PR TITLE
Fix #3: npm run lint fails

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,3 @@
+{
+  "parser": "babel-eslint"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .idea
+*.iml
 node_modules
 dist
 lib

--- a/src/__tests__/setup.js
+++ b/src/__tests__/setup.js
@@ -1,0 +1,1 @@
+// test setup to be implemented


### PR DESCRIPTION
Fix #3 – the following commands now succeed:
- `npm run lint`
- `npm run test`

Notes:
- there are no tests currently written
- the `eslint` styling rules are just the default ones
