### PR TITLE
Feature/example

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -6,4 +6,4 @@ test
 .idea
 .npmignore
 .travis.yml
-webpack.*
+webpack

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,33 @@
+# 0.0.6
+- **added** `allValues` and `allProps` params to validator.
+    It can be used to create validations that requires other fields value and props  like `matchField`.
+example:
+```javascript
+import FormMessages from 'redux-form-validation';
+
+FormMessages.addValidation('matchField', function(field, value, prop, dispatch, allValues, allProps){
+    return !value ? false : value != allValues[prop];
+})
+```
+
+- **added** `matchField` validation.
+    must give the matching field name as value.
+
+example:
+```javascript 
+var validations = {
+    email: {
+        required: true,
+        email: true,
+        validateOnBlur: true,
+    },
+    retryEmail: {
+        validateOnBlur: true,
+        matchField: 'email',
+  },
+}
+```
+- **added** example.
+    To run the example run `npm i -d && npm start`
+- **fixed** `FormMessage` component.
+    Render error when only has one child.

--- a/examples/index.html
+++ b/examples/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Title</title>
+    <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+<div id="root"></div>
+<script src="/bundle.js"></script>
+</body>
+</html>

--- a/examples/src/App.js
+++ b/examples/src/App.js
@@ -1,0 +1,13 @@
+import React, { Component } from 'react';
+import ContactForm from './contact-form';
+
+export default class App extends Component {
+  render() {
+    return (
+      <div>
+        <h1>Welcome to redux-form-validation</h1>
+        <ContactForm />
+      </div>
+    );
+  }
+}

--- a/examples/src/contact-form.js
+++ b/examples/src/contact-form.js
@@ -1,0 +1,149 @@
+import React, {Component, PropTypes} from 'react';
+import {reduxForm} from 'redux-form';
+import {connect} from 'react-redux';
+import FormMessages from 'redux-form-validation';
+import {generateValidation} from 'redux-form-validation';
+
+
+
+var validations = {
+  email: {
+    validateOnBlur: true,
+    required: true,
+    minLength: 5,
+    email: true,
+    promise: function (fieldName, fieldValue, dispatch) {
+      return new Promise((resolve, reject) => {
+        setTimeout(function () {
+          if (fieldValue == 'example@example.com') {
+            resolve()
+          } else {
+            reject('The mail must be example@example.com, "' + (fieldValue || 'none') + '" given!')
+          }
+        }, 1000)
+      })
+    }
+  },
+  retryEmail: {
+    required: true,
+    matchField: 'email',
+  },
+  name: {
+    required: true
+  },
+  subject: {
+    required: true,
+    minLength: 5
+  },
+  message: {
+    required: true,
+    minLength: 10
+  }
+};
+
+
+const submit = (values, dispatch) => {
+  console.log('sending mail to contact',  values);
+};
+
+@connect()
+@reduxForm({
+  form: 'contact',
+  ...generateValidation(validations)
+})
+export default class ContactForm extends Component {
+  render() {
+    const {
+      fields: {name, subject, email, retryEmail, message},
+      handleSubmit,
+      submitting,
+      valid,
+      pristine,
+      asyncValidating,
+      } = this.props;
+    var submitLabel = "Send";
+
+    if (pristine) {
+      submitLabel = "Fill in your message";
+    } else if(asyncValidating){
+      submitLabel= "Validating...";
+    } else if (submitting) {
+      submitLabel = "Sending...";
+    } else if(!valid){
+      submitLabel = "Please fill all fields correctly";
+    }
+    return (
+      <form onSubmit={handleSubmit(submit)}>
+        <div>
+          <label>Email</label>
+          <input type="email" required="required" placeholder="Email" {...email}/>
+          <FormMessages tagName="ul" field={email}>
+            <li when="promise">
+              {email.error && email.error.promise}
+            </li>
+            <li when="required">
+              this field is required
+            </li>
+            <li when="email">
+              please insert a valid email
+            </li>
+            <li when="minLength">
+              this field must have at least 5 characters
+            </li>
+          </FormMessages>
+        </div>
+        <div>
+          <label>Retry email</label>
+          <input type="email" required="required" placeholder="Retry email" {...retryEmail}/>
+          <FormMessages tagName="ul" field={retryEmail}>
+            <li when="required">
+              this field is required
+            </li>
+            <li when="matchField">
+              the retry email must be the same as the email
+            </li>
+          </FormMessages>
+        </div>
+        <div>
+          <label>Name</label>
+          <input type="text" required="required" placeholder="Name" {...name}/>
+          <FormMessages tagName="ul" field={name}>
+            <li when="required">
+              this field is required
+            </li>
+          </FormMessages>
+        </div>
+        <div>
+          <label>Subject</label>
+          <input type="text" required="required" placeholder="Subject" {...subject}/>
+          <FormMessages tagName="ul" errorCount="1" field={subject}>
+            <li when="required">
+              this field is required
+            </li>
+            <li when="email">
+              please insert a valid email
+            </li>
+            <li when="minLength">
+              this field must have at least 5 characters
+            </li>
+          </FormMessages>
+        </div>
+        <div>
+          <label>Message</label>
+          <textarea type="text" required="required" placeholder="Subject" {...message}/>
+          <FormMessages tagName="ul" field={message}>
+            <li when="required">
+              this field is required
+            </li>
+            <li when="minLength">
+              this field must have at least 10 characters
+            </li>
+          </FormMessages>
+        </div>
+        <button disabled={!valid || pristine || asyncValidating} onClick={handleSubmit(submit)}>
+          {submitLabel}
+        </button>
+      </form>
+    );
+  }
+}

--- a/examples/src/index.js
+++ b/examples/src/index.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import App from './app';
+
+import { Provider } from 'react-redux';
+
+import configureStore from './redux';
+
+const store = configureStore();
+
+ReactDOM.render(
+  (
+    <Provider store={store}>
+      <App />
+    </Provider>
+  ),
+  document.getElementById('root')
+);

--- a/examples/src/redux/index.js
+++ b/examples/src/redux/index.js
@@ -1,0 +1,16 @@
+import { createStore } from 'redux'
+import rootReducer from './root.reducer'
+
+export default function configureStore(initialState) {
+  const store = createStore(rootReducer, initialState)
+
+  if (module.hot) {
+    // Enable Webpack hot module replacement for reducers
+    module.hot.accept('./root.reducer', () => {
+      const nextReducer = require('./root.reducer').default
+      store.replaceReducer(nextReducer)
+    })
+  }
+
+  return store;
+}

--- a/examples/src/redux/root.reducer.js
+++ b/examples/src/redux/root.reducer.js
@@ -1,0 +1,6 @@
+import { combineReducers } from 'redux'
+import {reducer as formReducer} from 'redux-form';
+
+export default combineReducers({
+  form: formReducer
+});

--- a/examples/style.css
+++ b/examples/style.css
@@ -1,0 +1,15 @@
+
+label{
+    width:150px;
+    display: inline-block;
+    text-align: left;
+}
+button{
+    margin-top: 20px;
+}
+body{
+    text-align: center;
+}
+ul{
+    list-style: none;
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-form-validation",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "An helper to make redux form validation easyer",
   "main": "lib/index.js",
   "jsnext:main": "./src/index.js",
@@ -24,37 +24,45 @@
   "homepage": "https://github.com/CosticaPuntaru/redux-form-validation#readme",
   "peerDependencies": {
     "react-redux": "^3.0.0 || ^4.0.0",
-    "redux": "^3.0.0"
+    "redux": "^3.3.1",
+    "redux-form": "^4.1.8"
   },
   "scripts": {
+    "start": "webpack-dev-server --config ./webpack/example.js",
     "build": "npm run build:lib && npm run build:umd && npm run build:umd:min",
     "build:lib": "babel src --out-dir lib",
-    "build:umd": "webpack src/index.js dist/redux-form-validation.js --config webpack.config.development.js",
-    "build:umd:min": "webpack src/index.js dist/redux-form-validation.min.js --config webpack.config.production.js",
+    "build:umd": "webpack src/index.js dist/redux-form-validation.js --config webpack/development.js",
+    "build:umd:min": "webpack src/index.js dist/redux-form-validation.min.js --config webpack/production.js",
     "clean": "rimraf dist lib",
     "lint": "eslint src",
     "prepublish": "npm run clean && npm run build",
     "test": "npm run lint && mocha --compilers js:babel/register --recursive 'src/**/__tests__/*' --require src/__tests__/setup.js"
   },
   "devDependencies": {
+    "autoprefixer-loader": "^3.1.0",
     "babel": "^5.8.23",
     "babel-core": "^5.8.25",
     "babel-eslint": "^4.1.3",
     "babel-loader": "^5.3.2",
+    "css-loader": "^0.23.1",
     "eslint": "^1.9.0",
     "eslint-config-airbnb": "^0.1.0",
     "eslint-plugin-react": "^3.5.1",
     "expect": "^1.11.1",
+    "html-loader": "^0.4.0",
     "jsdom": "^7.0.1",
     "mocha": "^2.3.3",
-    "react": "^0.14.0",
+    "react": "^0.14.7",
     "react-addons-test-utils": "^0.14.0",
     "react-dom": "^0.14.0",
+    "react-hot-loader": "^1.3.0",
     "react-redux": "^3.1.0",
     "redux": "^3.0.2",
     "rifraf": "^2.0.2",
     "rimraf": "^2.4.3",
-    "webpack": "^1.12.3"
+    "style-loader": "^0.13.0",
+    "webpack": "^1.12.3",
+    "webpack-dev-server": "^1.14.0"
   },
   "npmName": "redux-form-validation",
   "npmFileMap": [
@@ -66,6 +74,6 @@
     }
   ],
   "dependencies": {
-    "is-promise": "^2.1.0"
+    "is-promise": "*"
   }
 }

--- a/src/basic-validations.js
+++ b/src/basic-validations.js
@@ -82,6 +82,8 @@ export default {
     }
 
     return ( nCheck % 10 ) === 0;
+  },
+  matchField: function(field, value, prop, dispatch, allValues){
+    return !value ? false : value != allValues[prop];
   }
-
 }

--- a/src/form-messages/index.js
+++ b/src/form-messages/index.js
@@ -2,47 +2,39 @@ import React, {Component, PropTypes} from 'react';
 
 export default class FormMessages extends Component {
 
-    renderChildren() {
-        const {children, field, errorCount} = this.props;
-        if (children && children.length && field && field.touched && field.error) {
-            var display = parseInt(errorCount, 10);
-            var toBeDisplayed = [];
-            var currentErrorCount = 0;
-            for (let i in children) {
-                let child = children[i];
-                if (child.props.when && field.error[child.props.when]) {
-                    toBeDisplayed.push(child);
-                    currentErrorCount++;
-                    if (display > 0 && currentErrorCount >= display) {
-                        break;
-                    }
-                }
-            }
-            return toBeDisplayed;
-        }
-    }
+  renderChildren(children, field, errorCount) {
+    if (field && field.touched && field.error) {
+      var errorList = React.Children.toArray(children)
+        .filter(function (child) {
+          return child.props.when && field.error[child.props.when]
+        });
 
-    render() {
-        const {children, field, errorCount, tagName, ...rest} = this.props;
-        const errorElements = this.renderChildren();
-        //if (!errorElements || !errorElements.length) {
-        //    return false;
-        //}
-        return (
-            <this.props.tagName {...rest}>
-                {errorElements}
-            </this.props.tagName>
-        )
+      var displayErrorCount = parseInt(errorCount, 10);
+      if (displayErrorCount < -1) {
+        return errorList;
+      }
+      return errorList.slice(0, displayErrorCount);
     }
+  }
+
+  render() {
+    const {children, field, errorCount, tagName, ...rest} = this.props;
+
+    return (
+      <this.props.tagName {...rest}>
+        { this.renderChildren(children, field, errorCount)}
+      </this.props.tagName>
+    )
+  }
 };
 
 FormMessages.propTypes = {
-    field: PropTypes.object.isRequired,
-    tagName: PropTypes.oneOfType([PropTypes.element, PropTypes.string]),
-    errorCount: PropTypes.oneOfType([PropTypes.number, PropTypes.string])
+  field: PropTypes.object.isRequired,
+  tagName: PropTypes.oneOfType([PropTypes.element, PropTypes.string]),
+  errorCount: PropTypes.oneOfType([PropTypes.number, PropTypes.string])
 };
 
 FormMessages.defaultProps = {
-    errorCount: -1,
-    tagName: 'div'
+  errorCount: -1,
+  tagName: 'div'
 };

--- a/src/validation.js
+++ b/src/validation.js
@@ -33,7 +33,7 @@ export function generateAsyncValidation(validationConfig) {
                     if (typeof validationStore[validationType] != 'function') {
                         return;
                     }
-                    var hasError = validationStore[validationType](fieldName, values[fieldName], validation[validationType], dispatch);
+                    var hasError = validationStore[validationType](fieldName, values[fieldName], validation[validationType], dispatch, values, validation);
                     if (isPromise(hasError)) {
                         promiseList.push(new Promise((resolve, reject)=> {
                             hasError.then(resolve).catch((msg) => {

--- a/webpack/base.js
+++ b/webpack/base.js
@@ -1,4 +1,3 @@
-'use strict';
 var webpack = require('webpack');
 
 var reactExternal = {

--- a/webpack/development.js
+++ b/webpack/development.js
@@ -1,13 +1,11 @@
 'use strict';
 
 var webpack = require('webpack');
-var baseConfig = require('./webpack.config.base');
+var baseConfig = require('./base');
 
 var config = Object.create(baseConfig);
 config.plugins = [
     new webpack.optimize.OccurenceOrderPlugin()
-
-
 ];
 
 module.exports = config;

--- a/webpack/example.js
+++ b/webpack/example.js
@@ -1,0 +1,47 @@
+var path = require("path");
+var webpack = require('webpack');
+var PORT = process.env.PORT || 3003;
+
+module.exports = {
+  devtool: 'inline-source-map',
+  entry: "./src/index.js",
+  context: path.resolve(process.cwd(), "examples"),
+  output: {
+    path: 'examples/.tmp',
+    filename: "bundle.js"
+  },
+  module: {
+    loaders: [
+      {
+        test: /\.(js|jsx)$/,
+        loaders: ['babel-loader?{"stage" : 0}'],
+        exclude: /node_modules/
+      },
+      {
+        test: /\.html$/,
+        loaders: ['html-loader'],
+      }
+    ]
+  },
+  plugins: [
+    new webpack.HotModuleReplacementPlugin(),
+  ],
+  resolve: {
+    root: [path.join(process.cwd(), 'examples')],
+    alias: {'redux-form-validation': path.join(process.cwd(), 'src/index.js')},
+    extensions: ['', '.js', '.jsx', '.es6', '.scss', '.css'],
+    modulesDirectories: [
+      'examples',
+      'node_modules',
+    ],
+  },
+  devServer: {
+    contentBase: 'examples',
+    noInfo: false, //  --no-info option
+    historyApiFallback: true,
+    progress: true,
+    hot: true,
+    inline: true,
+    port: PORT,
+  },
+};

--- a/webpack/index.js
+++ b/webpack/index.js
@@ -1,11 +1,14 @@
 'use strict';
 
 var webpack = require('webpack');
-var baseConfig = require('./webpack.config.base');
+var baseConfig = require('./base');
 
 var config = Object.create(baseConfig);
 config.plugins = [
     new webpack.optimize.OccurenceOrderPlugin(),
+    new webpack.DefinePlugin({
+        'process.env.NODE_ENV': JSON.stringify('production')
+    }),
     new webpack.optimize.UglifyJsPlugin({
         compressor: {
             screw_ie8: true,

--- a/webpack/production.js
+++ b/webpack/production.js
@@ -1,14 +1,11 @@
 'use strict';
 
 var webpack = require('webpack');
-var baseConfig = require('./webpack.config.base');
+var baseConfig = require('./base');
 
 var config = Object.create(baseConfig);
 config.plugins = [
     new webpack.optimize.OccurenceOrderPlugin(),
-    new webpack.DefinePlugin({
-        'process.env.NODE_ENV': JSON.stringify('production')
-    }),
     new webpack.optimize.UglifyJsPlugin({
         compressor: {
             screw_ie8: true,


### PR DESCRIPTION
#0.0.6
- **added** `allValues` and `allProps` params to validator.
  It can be used to create validations that requires other fields value and props  like `matchField`.
  example:

``` javascript
import FormMessages from 'redux-form-validation';

FormMessages.addValidation('matchField', function(field, value, prop, dispatch, allValues, allProps){
    return !value ? false : value != allValues[prop];
})
```
- **added** `matchField` validation.
  must give the matching field name as value.

example:

``` javascript
var validations = {
    email: {
        required: true,
        email: true,
        validateOnBlur: true,
    },
    retryEmail: {
        validateOnBlur: true,
        matchField: 'email',
  },
}
```
- **added** example.
  To run the example run `npm i -d && npm start`
- **fixed** `FormMessage` component.
  Render error when only has one child.
