### PR TITLE
Add dispatch param to promise validation

### DIFF
--- a/src/basic-validations.js
+++ b/src/basic-validations.js
@@ -41,9 +41,9 @@ export default {
     return !value ? false : !validUrl.isUri(value);
   },
 
-  promise: function (field, value, prop) {
+  promise: function (field, value, prop, dispatch) {
     if (typeof prop == 'function') {
-      return prop(field, value)
+      return prop(field, value, dispatch)
     }
     throw new Error("FormValidation: type promise must be a function!")
   },


### PR DESCRIPTION
Promise validation was not sending the dispatch function as a param to the promise validation type
